### PR TITLE
Squashed a bug related to deleting a Pinned Todo.

### DIFF
--- a/react-app/pomodoro-timer-ui/src/Components/TodoTab/Todo.jsx
+++ b/react-app/pomodoro-timer-ui/src/Components/TodoTab/Todo.jsx
@@ -31,6 +31,14 @@ export default function ({ todo, toggleComplete, removeTodo }) {
 
   function handleRemoveButton() {
     removeTodo(todo.id);
+    if (todo.id == pinnedTodo.id) {
+    setPinnedTodo({
+      id: "",
+      task: "",
+      is_completed: false,
+    });
+    setIsActivePin(false)
+  }
   }
 
   function handlePinButton() {


### PR DESCRIPTION
If a Pinned Todo was deleted from the list before unpinning it, the Pinned Todo does not get deleted and instead remains on the main page. This bug makes it impossible to make a new Pinned Todo.